### PR TITLE
Fix HTTP method name in CORS config

### DIFF
--- a/springboot/src/main/java/skku/gymbarofit/auth/CorsConfig.java
+++ b/springboot/src/main/java/skku/gymbarofit/auth/CorsConfig.java
@@ -26,7 +26,7 @@ public class CorsConfig {
         allowedHttpMethods.add("POST");
         allowedHttpMethods.add("PUT");
         allowedHttpMethods.add("DELETE");
-        allowedHttpMethods.add("OPTION");
+        allowedHttpMethods.add("OPTIONS");
         configuration.setAllowedMethods(allowedHttpMethods);
 
         // 모든 헤더 허용


### PR DESCRIPTION
## Summary
- correct allowed methods list in the CORS configuration

## Testing
- `./gradlew test --console plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fe495b8e88333bfac063f6f9ad8db