### PR TITLE
Fix password field in Login page

### DIFF
--- a/react-webapp/src/pages/Login.jsx
+++ b/react-webapp/src/pages/Login.jsx
@@ -59,7 +59,7 @@ export default function Login() {
                 required
                 fullWidth
                 id="pw"
-                type="pw"
+                type="password"
                 label="비밀번호"
                 name="pw"
                 autoComplete="current-password"
@@ -92,3 +92,4 @@ export default function Login() {
     </Container>
   );
 }
+


### PR DESCRIPTION
## Summary
- change input type in React Login page to `password` so field masks typed text

## Testing
- `./gradlew test --console=plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fe4ae7d14833381c7cb692d8d08b4