### PR TITLE
Refactor/equipemntUsage: 기구 20분 최대 사용 시간 제한 및 CI 수정

### DIFF
--- a/.github/workflows/k6-load-test.yml
+++ b/.github/workflows/k6-load-test.yml
@@ -53,7 +53,7 @@ jobs:
         working-directory: springboot
         env:
           JWT_SECRET: ${{ secrets.JWT_SECRET_TEST }}
-          K6_SEED_PATH: ${{ github.workspace }}/k6/seed/seed.sql
+          SPRING_SQL_INIT_DATA_LOCATIONS: file:${{ github.workspace }}/k6/seed/seed.sql
         run: |
           java -jar api/build/libs/api-*.jar \
             --spring.profiles.active=ci \
@@ -145,7 +145,7 @@ jobs:
         working-directory: springboot
         env:
           JWT_SECRET: ${{ secrets.JWT_SECRET_TEST }}
-          K6_SEED_PATH: ${{ github.workspace }}/k6/seed/seed.sql
+          SPRING_SQL_INIT_DATA_LOCATIONS: file:${{ github.workspace }}/k6/seed/seed.sql
         run: |
           java -jar api/build/libs/api-*.jar \
             --spring.profiles.active=ci \

--- a/README.md
+++ b/README.md
@@ -4,23 +4,50 @@
 
 ## 주요 기능
 
-- **헬스장 검색 및 등록** — 키워드·위치 기반 검색, 오너 헬스장 등록
-- **체크인 / 체크아웃** — 회원 출입 관리
-- **기구 사용 관리** — 사용 시작·종료, 대기열, 동시 사용 충돌 방지 (분산 락)
-- **라커 대여·반납** — 구역별 라커 조회 및 예약
-- **멤버십 관리** — 등록·조회
-- **실시간 알림** — SSE 기반 알림 (대기열 순번 등)
+**회원**
+- 헬스장 검색·회원권 등록
+- 체크인 / 체크아웃
+- 기구 실시간 예약·대기열 (분산 락으로 동시 충돌 방지)
+- 라커 대여·연장·환불
+- 운동 이력·통계 대시보드
+- AI 운동 분석 (Gemma4 파인튜닝 모델 기반 스트리밍)
+- 실시간 알림 (SSE — 대기열 순번 등)
+
+**운영자**
+- 헬스장 3단계 등록 마법사 (기본 정보 → 라커 → 기구/맵)
+- 인터랙티브 캔버스 맵 에디터 (Konva)
+- 기구·라커 CRUD, 혼잡도 관리
+- 회원 관리 (등록 회원 조회·상태 변경)
+- 통계 대시보드
+
+**공통**
+- JWT (Access + Refresh Token) 기반 인증
+- 회원권·대여권 만료 자동 처리 (Spring Batch)
 
 ## 기술 스택
 
 | 영역 | 기술 |
 |---|---|
-| Frontend | React 18, Vite, Material UI |
-| Backend | Spring Boot 3, Spring Security, JPA |
-| Database | PostgreSQL 16 (운영·Docker), H2 (로컬 개발) |
-| Cache / Lock | Redis 7, Redisson (분산 락) |
+| Frontend | React 19, Vite 7, Material UI 7, Konva, Recharts |
+| Backend | Spring Boot 3.4.4, Spring Security, JPA, Java 21 (Virtual Threads) |
+| Batch | Spring Batch (회원권·대여권 만료 처리) |
+| AI | FastAPI + Gemma4 파인튜닝 모델 (옵션) |
+| Database | PostgreSQL 16 (Docker/운영), H2 (로컬 개발) |
+| Cache / Lock | Redis 7, Redisson (분산 락 + 캐시) |
 | Auth | JWT (Access + Refresh Token) |
 | Infra | Docker Compose, GitHub Actions |
+
+## 프로젝트 구조
+
+```
+gymbarofit/
+├── react-vite/          — React 프론트엔드
+├── springboot/
+│   ├── core/            — 도메인 엔티티, 레포지토리, InternalService
+│   ├── api/             — REST 컨트롤러, 보안, AOP, Redis
+│   └── batch/           — 회원권·대여권 만료 자동 처리 스케줄러
+└── gemma4/              — FastAPI AI 서버 (옵션)
+```
 
 ---
 
@@ -44,18 +71,25 @@ SPRING_PROFILES_ACTIVE=docker
 POSTGRES_USERNAME=gymbarofit
 POSTGRES_PASSWORD=gymbarofit1234
 JWT_SECRET=<your-jwt-secret>
+FASTAPI_BASE_URL=http://gemma4-ai:8000
 ```
 
 **2. 실행**
 
 ```bash
+# 기본 실행 (AI 서버 제외)
 docker compose up -d
+
+# AI 서버 포함 실행 (GPU 필요)
+docker compose --profile ai up -d
 ```
 
 | 서비스 | 주소 |
 |---|---|
 | 프론트엔드 | http://localhost:5173 |
 | 백엔드 API | http://localhost:8080 |
+| Batch 서버 | http://localhost:8081 |
+| AI 서버 | http://localhost:8000 (`--profile ai` 시) |
 
 **3. 종료**
 
@@ -95,8 +129,8 @@ npm run dev
 
 `main` 브랜치 push·PR 시 GitHub Actions에서 K6 성능 테스트가 자동 실행됩니다.
 
-- **Smoke Test** — 모든 PR에서 실행 (로그인·검색 기본 흐름)
-- **Concurrency Test** — `main` 병합 시 실행 (분산 락·비관적 락 동시성 검증)
+- **Smoke Test** — `main`·`dev` 대상 모든 PR에서 실행 (로그인·검색 기본 흐름)
+- **Concurrency Test** — `main` PR 병합 시 또는 수동 실행 (분산 락·비관적 락 동시성 검증)
 
 필요한 GitHub Secrets:
 
@@ -104,6 +138,3 @@ npm run dev
 |---|---|
 | `JWT_SECRET_TEST` | 테스트용 JWT 서명 키 |
 | `K6_TEST_PASSWORD` | K6 테스트 계정 비밀번호 |
-
-
-TODO: batch로 회원권 및 대여권 만료 상태 처리 구현 필요

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: gymbarofit-redis
+    command: redis-server --notify-keyspace-events Ex
     ports:
       - "6379:6379"
     volumes:

--- a/react-vite/src/components/members/dashboard/EquipmentCard.jsx
+++ b/react-vite/src/components/members/dashboard/EquipmentCard.jsx
@@ -1,9 +1,70 @@
-import { Paper, Box, Typography, Button, Chip, Stack, IconButton } from "@mui/material";
+import { useState, useEffect } from "react";
+import { Paper, Box, Typography, Button, Chip, Stack, IconButton, LinearProgress } from "@mui/material";
 import FitnessCenterIcon from "@mui/icons-material/FitnessCenter";
 import EventAvailableIcon from "@mui/icons-material/EventAvailable";
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import MapIcon from "@mui/icons-material/Map";
+import TimerIcon from "@mui/icons-material/Timer";
+
+const USAGE_LIMIT_MS = 20 * 60 * 1000;
+
+function UsageTimer({ startAtMs }) {
+  const [remaining, setRemaining] = useState(() => {
+    if (!startAtMs) return USAGE_LIMIT_MS;
+    return Math.max(0, USAGE_LIMIT_MS - (Date.now() - startAtMs));
+  });
+
+  useEffect(() => {
+    if (!startAtMs) return;
+    const tick = () => {
+      setRemaining(Math.max(0, USAGE_LIMIT_MS - (Date.now() - startAtMs)));
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [startAtMs]);
+
+  const totalSec = Math.ceil(remaining / 1000);
+  const minutes = Math.floor(totalSec / 60);
+  const seconds = totalSec % 60;
+  const timeStr = `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  const progress = (remaining / USAGE_LIMIT_MS) * 100;
+  const isUrgent = remaining <= 5 * 60 * 1000;
+
+  return (
+    <Box sx={{ mt: 0.5, mb: 1.2 }}>
+      <Box display="flex" alignItems="center" gap={0.5} mb={0.6}>
+        <TimerIcon sx={{ fontSize: 13, color: isUrgent ? "error.main" : "warning.main" }} />
+        <Typography
+          variant="h6"
+          fontWeight="900"
+          lineHeight={1}
+          color={isUrgent ? "error.main" : "warning.dark"}
+          sx={{ fontVariantNumeric: "tabular-nums", letterSpacing: 1 }}
+        >
+          {timeStr}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" fontWeight={600} sx={{ ml: 0.3 }}>
+          남음
+        </Typography>
+      </Box>
+      <LinearProgress
+        variant="determinate"
+        value={progress}
+        sx={{
+          height: 5,
+          borderRadius: 3,
+          bgcolor: "#f5f5f5",
+          "& .MuiLinearProgress-bar": {
+            bgcolor: isUrgent ? "error.main" : "warning.main",
+            borderRadius: 3,
+          },
+        }}
+      />
+    </Box>
+  );
+}
 
 const SECTION_STYLES = {
   usage:   { bg: '#fff8e1', border: '#ffe0b2', textColor: 'warning.dark',   chip: 'warning' },
@@ -53,12 +114,16 @@ function EquipmentSection({ data, titleIcon, titleText, statusLabel, variant, ac
           <Typography variant="subtitle2" fontWeight="800" color="text.primary" mb={0.3}>
             {data.name}
           </Typography>
-          <Box display="flex" alignItems="center" mb={1.2}>
-            <AccessTimeIcon sx={{ fontSize: 13, mr: 0.4, color: variant === 'called' ? 'error.main' : 'text.disabled' }} />
-            <Typography variant="caption" fontWeight="700" color={variant === 'called' ? 'error.main' : 'text.secondary'}>
-              {data.time}
-            </Typography>
-          </Box>
+          {variant === 'usage' && data.startAtMs ? (
+            <UsageTimer startAtMs={data.startAtMs} />
+          ) : (
+            <Box display="flex" alignItems="center" mb={1.2}>
+              <AccessTimeIcon sx={{ fontSize: 13, mr: 0.4, color: variant === 'called' ? 'error.main' : 'text.disabled' }} />
+              <Typography variant="caption" fontWeight="700" color={variant === 'called' ? 'error.main' : 'text.secondary'}>
+                {data.time}
+              </Typography>
+            </Box>
+          )}
 
           {variant === 'called' ? (
             <Stack direction="row" spacing={1}>

--- a/react-vite/src/hooks/useDashboard.js
+++ b/react-vite/src/hooks/useDashboard.js
@@ -64,6 +64,7 @@ export function useDashboard(initialGym) {
 
       const newEquipInfo = { usage: null, reservation: null };
       const eq = res.equipmentUsage;
+      console.log("[DEBUG] inUseDto:", eq?.inUseDto);
       if (eq?.inUseDto) {
         newEquipInfo.usage = {
           uid: eq.inUseDto.usageId,
@@ -71,6 +72,7 @@ export function useDashboard(initialGym) {
           name: eq.inUseDto.name,
           imageUrl: eq.inUseDto.imageUrl ? `${BUCKET_BASE_URL}${eq.inUseDto.imageUrl}` : "",
           time: "현재 이용 중",
+          startAtMs: eq.inUseDto.startAtMs ?? null,
         };
       }
       if (eq?.waitingDto) {

--- a/react-vite/src/pages/gyms/EquipmentReservation.jsx
+++ b/react-vite/src/pages/gyms/EquipmentReservation.jsx
@@ -247,6 +247,9 @@ export default function EquipmentReservation() {
       {/* 맨 아래에 위치하는 안내 문구 (flex flow상 마지막) */}
       <Box sx={{ p: 2, bgcolor: "#f5f7fa", mt: 2 }}>
           <Box sx={{ bgcolor: "#f0f2f5", p: 1.5, borderRadius: 2 }}>
+            <Typography variant="caption" display="block" color="text.secondary" sx={{ fontWeight: 500 }}>
+                • 기구 최대 사용 시간은 20분입니다.
+            </Typography>
             <Typography variant="caption" display="block" color="text.secondary" sx={{ mb: 0.5, fontWeight: 500 }}>
                 • 회원당 하나의 기구만 사용 및 예약 가능합니다.
             </Typography>

--- a/springboot/api/src/main/java/skku/gymbarofit/api/config/RedisConfig.java
+++ b/springboot/api/src/main/java/skku/gymbarofit/api/config/RedisConfig.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -86,6 +87,15 @@ public class RedisConfig {
         mapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
 
         return mapper;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedissonConnectionFactory connectionFactory
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
     }
 
     @Bean

--- a/springboot/api/src/main/java/skku/gymbarofit/api/equipment/EquipmentService.java
+++ b/springboot/api/src/main/java/skku/gymbarofit/api/equipment/EquipmentService.java
@@ -54,6 +54,7 @@ public class EquipmentService {
     private final NotificationFacade notificationFacade;
     private final EquipmentLogInternalService equipmentLogInternalService;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final EquipmentUsageTtlService equipmentUsageTtlService;
     private final Clock clock;
 
     @Transactional(readOnly = true)
@@ -137,6 +138,7 @@ public class EquipmentService {
                 EquipmentLog.from(usage, EquipmentEventType.USAGE_STARTED, clock)
         );
 
+        equipmentUsageTtlService.registerTtlAfterCommit(usage.getId());
         return usage.getId();
     }
 
@@ -147,6 +149,7 @@ public class EquipmentService {
 
         EquipmentUsage currentUsage = equipmentUsageInternalService.findByIdForUpdate(usageId);
         currentUsage.endUse(currentUsage.getMember().getWeight(), clock);
+        equipmentUsageTtlService.deleteTtl(usageId);
 
         Long equipmentId = currentUsage.getEquipment().getId();
         EquipmentUsage firstWaiting = equipmentUsageInternalService.findFirstWaitingForUpdate(equipmentId);
@@ -173,6 +176,31 @@ public class EquipmentService {
 
         equipmentLogInternalService.save(
                 EquipmentLog.from(usage, EquipmentEventType.USAGE_STARTED, clock)
+        );
+
+        equipmentUsageTtlService.registerTtlAfterCommit(usageId);
+    }
+
+    @CacheEvict(value = "equipment:usage:active", allEntries = true)
+    @DistributedLock(key = "'usage:' + #usageId")
+    @NotifyEquipmentChange
+    public void forceEndUsage(@UsageId Long usageId) {
+        EquipmentUsage currentUsage = equipmentUsageInternalService.findByIdForUpdate(usageId);
+        if (currentUsage.getStatus() != EquipmentUsageStatus.IN_USE) {
+            return;
+        }
+        currentUsage.endUse(currentUsage.getMember().getWeight(), clock);
+
+        Long equipmentId = currentUsage.getEquipment().getId();
+        EquipmentUsage firstWaiting = equipmentUsageInternalService.findFirstWaitingForUpdate(equipmentId);
+
+        if (firstWaiting != null) {
+            firstWaiting.call();
+            applicationEventPublisher.publishEvent(new WaitingAvailableEvent(firstWaiting.getMember().getId(), equipmentId));
+        }
+
+        equipmentLogInternalService.save(
+                EquipmentLog.from(currentUsage, EquipmentEventType.USAGE_FORCE_ENDED, clock)
         );
     }
 

--- a/springboot/api/src/main/java/skku/gymbarofit/api/equipment/EquipmentUsageTtlService.java
+++ b/springboot/api/src/main/java/skku/gymbarofit/api/equipment/EquipmentUsageTtlService.java
@@ -1,0 +1,32 @@
+package skku.gymbarofit.api.equipment;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class EquipmentUsageTtlService {
+
+    static final String KEY_PREFIX = "usage:force_end:";
+    private static final long TTL_SECONDS = 1200L;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void registerTtlAfterCommit(Long usageId) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                redisTemplate.opsForValue().set(KEY_PREFIX + usageId, String.valueOf(usageId), TTL_SECONDS, TimeUnit.SECONDS);
+            }
+        });
+    }
+
+    public void deleteTtl(Long usageId) {
+        redisTemplate.delete(KEY_PREFIX + usageId);
+    }
+}

--- a/springboot/api/src/main/java/skku/gymbarofit/api/equipment/RedisKeyExpirationListener.java
+++ b/springboot/api/src/main/java/skku/gymbarofit/api/equipment/RedisKeyExpirationListener.java
@@ -1,0 +1,41 @@
+package skku.gymbarofit.api.equipment;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+import skku.gymbarofit.api.global.lock.LockAcquisitionException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisKeyExpirationListener implements MessageListener {
+
+    private final RedisMessageListenerContainer listenerContainer;
+    private final EquipmentService equipmentService;
+
+    @PostConstruct
+    public void init() {
+        listenerContainer.addMessageListener(this, new PatternTopic("__keyevent@*__:expired"));
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String expiredKey = new String(message.getBody());
+        if (!expiredKey.startsWith(EquipmentUsageTtlService.KEY_PREFIX)) {
+            return;
+        }
+        Long usageId = Long.parseLong(expiredKey.substring(EquipmentUsageTtlService.KEY_PREFIX.length()));
+        try {
+            equipmentService.forceEndUsage(usageId);
+        } catch (LockAcquisitionException e) {
+            log.debug("forceEndUsage 락 획득 실패 — 다른 인스턴스가 처리 중. usageId={}", usageId);
+        } catch (Exception e) {
+            log.error("forceEndUsage 처리 중 예외 발생. usageId={}", usageId, e);
+        }
+    }
+}

--- a/springboot/api/src/main/resources/application-ci.yml
+++ b/springboot/api/src/main/resources/application-ci.yml
@@ -20,6 +20,9 @@ spring:
       enabled: false
 
 app:
+  ai:
+    fastapi:
+      base-url: http://localhost:8000
   upload:
     dir: /tmp/gymbarofit-ci
   jwt:

--- a/springboot/api/src/main/resources/application.yml
+++ b/springboot/api/src/main/resources/application.yml
@@ -26,6 +26,10 @@ management:
       application: gymbarofit
 
 spring:
+  data:
+    redis:
+      repositories:
+        enabled: false
   threads:
     virtual:
       enabled: true

--- a/springboot/core/src/main/java/skku/gymbarofit/core/log/enums/EquipmentEventType.java
+++ b/springboot/core/src/main/java/skku/gymbarofit/core/log/enums/EquipmentEventType.java
@@ -5,5 +5,6 @@ public enum EquipmentEventType {
     WAIT_CANCELLED,
     WAIT_CALLED,
     USAGE_STARTED,
-    USAGE_ENDED
+    USAGE_ENDED,
+    USAGE_FORCE_ENDED
 }

--- a/springboot/core/src/main/java/skku/gymbarofit/core/usage/equipment/dto/EquipmentUsageDetailResponseDto.java
+++ b/springboot/core/src/main/java/skku/gymbarofit/core/usage/equipment/dto/EquipmentUsageDetailResponseDto.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import skku.gymbarofit.core.item.equipment.Equipment;
 import skku.gymbarofit.core.usage.equipment.EquipmentUsage;
 
+import java.time.ZoneId;
+
 @Slf4j
 @Builder
 public record EquipmentUsageDetailResponseDto(
@@ -12,11 +14,16 @@ public record EquipmentUsageDetailResponseDto(
     Long equipmentId,
     String name,
     String imageUrl,
-    int waitingCount
+    int waitingCount,
+    Long startAtMs
 ) {
 
     public static EquipmentUsageDetailResponseDto from(EquipmentUsage usage, Equipment equipment, int waitingCount) {
         if (usage == null) return null;
+
+        Long startAtMs = usage.getStartAt() != null
+                ? usage.getStartAt().atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli()
+                : null;
 
         return EquipmentUsageDetailResponseDto.builder()
                 .usageId(usage.getId())
@@ -24,6 +31,7 @@ public record EquipmentUsageDetailResponseDto(
                 .name(equipment.getItemInfo().getName())
                 .imageUrl(equipment.getImageUrl())
                 .waitingCount(waitingCount)
+                .startAtMs(startAtMs)
                 .build();
     }
 }


### PR DESCRIPTION
- Redis TTL + keyspace expiration으로 20분 초과 사용 시 자동 강제 종료 (EquipmentUsageTtlService, RedisKeyExpirationListener)
- EquipmentService에 forceEndUsage() 추가 및 사용 시작/종료 시 TTL 등록/삭제 연동
- EquipmentEventType에 USAGE_FORCE_ENDED 추가, docker-compose Redis keyspace 이벤트 활성화
- 대시보드 EquipmentCard에 20분 카운트다운 타이머 UI 추가 (startAtMs 기반)
- application-ci.yml FASTAPI_BASE_URL 누락으로 CI 서버 미기동 문제 수정
- k6 워크플로우 K6_SEED_PATH → SPRING_SQL_INIT_DATA_LOCATIONS로 수정해 seed SQL 실제 로드